### PR TITLE
Insuring that when the user resets his Advertising ID, the system isn't ...

### DIFF
--- a/appspice/src/main/java/it/appspice/android/providers/UniqueIdProvider.java
+++ b/appspice/src/main/java/it/appspice/android/providers/UniqueIdProvider.java
@@ -47,7 +47,8 @@ public class UniqueIdProvider {
                 Log.e(TAG, e.getMessage());
             }
 
-            if (adInfo != null) {
+            // Checks whether the user has limit ad tracking enabled or not
+            if (adInfo != null && !adInfo.isLimitAdTrackingEnabled()) {
                 return adInfo.getId();
             }
 
@@ -70,7 +71,9 @@ public class UniqueIdProvider {
             } catch (Exception e) {
                 try {
                     GooglePlayServicesUtil.getErrorDialog(result, (Activity) ctx, 0).show();
-                } catch (Exception ex) {}
+                } catch (Exception ex) {
+                    Log.e(TAG, ex.getMessage());
+                }
             }
         } else {
             task.execute();


### PR DESCRIPTION
...using his previous one for further requests and instead creates a new user.

This is needed because of the Google Policy regarding advertisement:

Respecting users' selections. Upon reset, a new advertising identifier must not be connected to a previous advertising identifier or data derived from a previous advertising identifier without the explicit consent of the user. Furthermore, you must abide by a user’s “opt out of interest-based advertising” setting. If a user has enabled this setting, you may not use the advertising identifier for creating user profiles for advertising purposes or for targeting users with interest-based advertising. Allowed activities include contextual advertising, frequency capping, conversion tracking, reporting and security and fraud detection.

https://play.google.com/about/developer-content-policy.html
